### PR TITLE
[Feature #159356713] Cache nutritional values for plans

### DIFF
--- a/wger/nutrition/models.py
+++ b/wger/nutrition/models.py
@@ -32,6 +32,8 @@ from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 from django.utils import translation
 from django.conf import settings
+from django.db.models.signals import post_save, post_delete
+from django.dispatch import receiver
 
 from wger.core.models import Language
 from wger.utils.constants import TWOPLACES
@@ -109,50 +111,68 @@ class NutritionPlan(models.Model):
         '''
         Sums the nutritional info of all items in the plan
         '''
-        use_metric = self.user.userprofile.use_metric
-        unit = 'kg' if use_metric else 'lb'
-        result = {'total': {'energy': 0,
-                            'protein': 0,
-                            'carbohydrates': 0,
-                            'carbohydrates_sugar': 0,
-                            'fat': 0,
-                            'fat_saturated': 0,
-                            'fibres': 0,
-                            'sodium': 0},
-                  'percent': {'protein': 0,
-                              'carbohydrates': 0,
-                              'fat': 0},
-                  'per_kg': {'protein': 0,
-                             'carbohydrates': 0,
-                             'fat': 0},
-                  }
+        result = cache.get(cache_mapper.get_nutrition_item(self.id))
+        if not result:
+            use_metric = self.user.userprofile.use_metric
+            unit = 'kg' if use_metric else 'lb'
+            result = {'total': {'energy': 0,
+                                'protein': 0,
+                                'carbohydrates': 0,
+                                'carbohydrates_sugar': 0,
+                                'fat': 0,
+                                'fat_saturated': 0,
+                                'fibres': 0,
+                                'sodium': 0},
+                      'percent': {'protein': 0,
+                                  'carbohydrates': 0,
+                                  'fat': 0},
+                      'per_kg': {'protein': 0,
+                                 'carbohydrates': 0,
+                                 'fat': 0},
+                      }
 
-        # Energy
-        for meal in self.meal_set.select_related():
-            values = meal.get_nutritional_values(use_metric=use_metric)
-            for key in result['total'].keys():
-                result['total'][key] += values[key]
+            # Energy
+            for meal in self.meal_set.select_related():
+                values = meal.get_nutritional_values(use_metric=use_metric)
+                for key in result['total'].keys():
+                    result['total'][key] += values[key]
 
-        energy = result['total']['energy']
+            energy = result['total']['energy']
 
-        # In percent
-        if energy:
-            for key in result['percent'].keys():
-                result['percent'][key] = \
-                    result['total'][key] * ENERGY_FACTOR[key][unit] / energy * 100
+            # In percent
+            if energy:
+                for key in result['percent'].keys():
+                    result['percent'][key] = \
+                        result['total'][key] * ENERGY_FACTOR[key][unit] / energy * 100
 
-        # Per body weight
-        weight_entry = self.get_closest_weight_entry()
-        if weight_entry:
-            for key in result['per_kg'].keys():
-                result['per_kg'][key] = result['total'][key] / weight_entry.weight
+            # Per body weight
+            weight_entry = self.get_closest_weight_entry()
+            if weight_entry:
+                for key in result['per_kg'].keys():
+                    result['per_kg'][key] = result['total'][key] / weight_entry.weight
 
-        # Only 2 decimal places, anything else doesn't make sense
-        for key in result.keys():
-            for i in result[key]:
-                result[key][i] = Decimal(result[key][i]).quantize(TWOPLACES)
+            # Only 2 decimal places, anything else doesn't make sense
+            for key in result.keys():
+                for i in result[key]:
+                    result[key][i] = Decimal(result[key][i]).quantize(TWOPLACES)
+
+            cache.set(cache_mapper.get_nutrition_item(self.id), result)
+            cache.get(cache_mapper.get_nutrition_item(self.id))
+            cache.close()
 
         return result
+
+    @staticmethod
+    def get_nutritional_plans(user):
+        """Static method to get nutritional plans"""
+        plans_dict = cache.get('nutritional_plans')
+        if not plans_dict:
+            plans_dict = {}
+            plans = NutritionPlan.objects.filter(user=user)[:50]
+            for plan in plans:
+                plans_dict["plan-{}".format(plan.id)] = plan
+                cache.set('nutritional_plans', plans_dict)
+        return plans_dict.values()
 
     def get_closest_weight_entry(self):
         '''
@@ -675,3 +695,18 @@ class MealItem(models.Model):
             nutritional_info[i] = Decimal(nutritional_info[i]).quantize(TWOPLACES)
 
         return nutritional_info
+
+
+@receiver(post_save, sender=NutritionPlan)
+@receiver(post_delete, sender=NutritionPlan)
+@receiver(post_save, sender=Meal)
+@receiver(post_delete, sender=Meal)
+@receiver(post_save, sender=MealItem)
+@receiver(post_delete, sender=MealItem)
+def handle_cache(sender, **kwargs):
+    """Make sure database is deleted when database changes"""
+    model = kwargs.get('instance')
+    if isinstance(model, (Meal, MealItem)):
+        cache.delete(cache_mapper.get_nutrition_item(model.get_owner_object().id))
+    else:
+        cache.delete(cache_mapper.get_nutrition_item(model.id))

--- a/wger/nutrition/views/plan.py
+++ b/wger/nutrition/views/plan.py
@@ -64,7 +64,7 @@ def overview(request):
     template_data = {}
     template_data.update(csrf(request))
 
-    plans = NutritionPlan.objects.filter(user=request.user)
+    plans = NutritionPlan.get_nutritional_plans(user=request.user)
     template_data['plans'] = plans
 
     return render(request, 'plan/overview.html', template_data)

--- a/wger/utils/cache.py
+++ b/wger/utils/cache.py
@@ -67,6 +67,7 @@ class CacheKeyMapper(object):
     INGREDIENT_CACHE_KEY = 'ingredient-{0}'
     WORKOUT_CANONICAL_REPRESENTATION = 'workout-canonical-representation-{0}'
     WORKOUT_LOG_LIST = 'workout-log-hash-{0}'
+    NUTRITION_CACHE_KEY = 'nutrition-{0}'
 
     def get_pk(self, param):
         '''
@@ -114,6 +115,10 @@ class CacheKeyMapper(object):
         Return the workout canonical representation
         '''
         return self.WORKOUT_LOG_LIST.format(hash_value)
+
+    def get_nutrition_item(self, param):
+        """Return nutrition cache key"""
+        return self.NUTRITION_CACHE_KEY.format(self.get_pk(param))
 
 
 cache_mapper = CacheKeyMapper()


### PR DESCRIPTION
**What does this PR do?**
- Cache nutritional values for plan

**Description of Task to be completed?**
- If a user has many plans (approx. more than 25), the overview renders slowly as too many DB-queries are fired just to calculate the total calories. Some caching of the values is probably the easiest solution, similar to the canonical_representation for workouts.
**Steps:**
- cache the nutritional_info dictionary in NutritionPlans
- add signals that delete the cache key everytime a NutritionPlan, Meal and MealItem is added, edited or deleted.

**What are the relevant pivotal tracker stories?**
- https://www.pivotaltracker.com/story/show/159356713

**Screenshots**
- With Cache
<img width="1367" alt="screen shot 2018-08-08 at 18 45 59" src="https://user-images.githubusercontent.com/32410518/43848903-b0ba9cb8-9b3c-11e8-841d-5de7c5f5010c.png">
- Without Cache
<img width="1288" alt="screen shot 2018-08-08 at 18 46 23" src="https://user-images.githubusercontent.com/32410518/43848949-d03051a0-9b3c-11e8-82bc-c91e67d80d19.png">
