### PR TITLE
#159356717 Add Support For Drop Sets

### DIFF
--- a/wger/manager/templates/set/formset.html
+++ b/wger/manager/templates/set/formset.html
@@ -2,12 +2,43 @@
 {% load i18n %}
 <div id="formset-exercise-{{exercise.id}}" style="margin-top: 1em;">
 <div class="row">
+    <div>
+        <div class="form-group">
+            <label class="col-md-3 control-label">
+                Drop sets
+            </label>
+            <div class=" col-md-9">
+                <span class="help-block">
+                    To do drop sets choose the initial weight, the number of repetitions on each set and the amount of weight to drop on each set.
+                    <br/>
+                    <a href="https://en.wikipedia.org/wiki/Drop_set">What is a Drop Set?</a>
+                </span>
+                <div class="col-xs-4">
+                    <input type="number" id="weight-{{exercise.id}}" class="form-control" placeholder="Start Weight">
+                </div>
+                 <div class="col-xs-4">
+                    <input type="number" id="reps-{{exercise.id}}" class="form-control" placeholder="Reps">
+                </div>
+                <div class="col-xs-4">
+                    <input type="number" id="drop-{{exercise.id}}" class="form-control" placeholder="Drop By">
+                </div>
+                <br/>
+                <br/>
+                <div class="col-xs-12">
+                    <button type="button" class="btn btn-primary  btn-lg btn-block" onclick='DropSet({{exercise.id}})'>
+                        Calculate Drop Set
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
     <div class="col-md-offset-2 col-md-10">
         <label class="control-label">
             {{exercise}}
         </label>
     </div>
 </div>
+<div>
 {{ formset.management_form }}
 
 {% for field in formset %}
@@ -71,3 +102,8 @@
 </div>
 {% endfor %}
 </div>
+<script>
+    function DropSet(workoutId) {
+        alert(workoutId);              // The function returns the product of p1 and p2
+    }
+</script>

--- a/wger/manager/templates/set/formset.html
+++ b/wger/manager/templates/set/formset.html
@@ -1,37 +1,41 @@
 {% load wger_extras %}
 {% load i18n %}
-<div id="formset-exercise-{{exercise.id}}" style="margin-top: 1em;">
-<div class="row">
-    <div>
-        <div class="form-group">
-            <label class="col-md-3 control-label">
-                Drop sets
-            </label>
-            <div class=" col-md-9">
-                <span class="help-block">
-                    To do drop sets choose the initial weight, the number of repetitions on each set and the amount of weight to drop on each set.
-                    <br/>
-                    <a href="https://en.wikipedia.org/wiki/Drop_set">What is a Drop Set?</a>
-                </span>
-                <div class="col-xs-4">
-                    <input type="number" id="weight-{{exercise.id}}" class="form-control" placeholder="Start Weight">
-                </div>
-                 <div class="col-xs-4">
-                    <input type="number" id="reps-{{exercise.id}}" class="form-control" placeholder="Reps">
-                </div>
-                <div class="col-xs-4">
-                    <input type="number" id="drop-{{exercise.id}}" class="form-control" placeholder="Drop By">
-                </div>
+<div>
+    <div class="form-group">
+        <label class="col-md-3 control-label">
+            Drop sets
+        </label>
+        <div class=" col-md-9">
+            <span class="help-block">
+                To do drop sets choose the initial weight, the number of repetitions on each set and the amount of weight to drop on each set.
                 <br/>
-                <br/>
-                <div class="col-xs-12">
-                    <button type="button" class="btn btn-primary  btn-lg btn-block" onclick='DropSet({{exercise.id}})'>
-                        Calculate Drop Set
-                    </button>
-                </div>
+                <a href="https://en.wikipedia.org/wiki/Drop_set">What is a Drop Set?</a>
+            </span>
+            <div class="col-xs-6">
+                <input type="number" id="weight-{{exercise.id}}" class="form-control" placeholder="Start Weight">
+            </div>
+            <div class="col-xs-6">
+                <input type="number" id="drop-weight-{{exercise.id}}" class="form-control" placeholder="Drop Weight By">
+            </div>
+            <br/><br/><br/>
+            <div class="col-xs-6">
+                <input type="number" id="reps-{{exercise.id}}" class="form-control" placeholder="Start Reps">
+            </div>
+            <div class="col-xs-6">
+                <input type="number" id="drop-reps-{{exercise.id}}" class="form-control" placeholder="Drop Reps By">
+            </div>
+            <br/>
+            <br/>
+            <div class="col-xs-12">
+                <button type="button" class="btn btn-primary  btn-lg btn-block" onclick='DropSet({{exercise.id}})'>
+                    Calculate Drop Set
+                </button>
             </div>
         </div>
     </div>
+</div>
+<div id="formset-exercise-{{exercise.id}}" style="margin-top: 1em;">
+<div class="row">
     <div class="col-md-offset-2 col-md-10">
         <label class="control-label">
             {{exercise}}
@@ -104,6 +108,30 @@
 </div>
 <script>
     function DropSet(workoutId) {
-        alert(workoutId);              // The function returns the product of p1 and p2
+        var numOfSets = document.getElementById('id_sets').value;
+        var reps = document.getElementById(`reps-${workoutId}`).value;
+        var weight = document.getElementById(`weight-${workoutId}`).value;
+        var dropWeight = document.getElementById(`drop-weight-${workoutId}`).value;
+        var dropReps = document.getElementById(`drop-reps-${workoutId}`).value;
+        var repsEntry = '';
+        var weightEntry = '';
+        console.log(dropWeight, dropReps, reps, weight);
+        if (!((reps > 0) && (weight > 0) && (dropReps.length === '' || dropReps >= 0) && (dropWeight > 0))) {
+            alert('Please ensure you enter all 4 Drop Set fields as positive integers')
+        } else {
+            for (var i = 0; i < numOfSets; i++){
+                repsEntry = 'id_exercise' + workoutId + '-' + i + '-reps';
+                weightEntry = 'id_exercise' + workoutId + '-' + i + '-weight';
+                document.getElementById(repsEntry).value = reps;
+                document.getElementById(weightEntry).value = weight;
+                weight -= dropWeight;
+                reps -= dropReps;
+                if (weight < 2 || reps < 1) {
+                    break;
+                }
+
+            }
+        }
+
     }
 </script>


### PR DESCRIPTION
#### What does this PR do?
Allow a user to enter base information and have the values of a drop set calculated for them automatically

#### Description of Task to be completed?
When a user enters the values required for a drop set ie. Initial weight, Weight to Drop, Initial Reps and Reps to Drop; the system will calculate the values for them and enter them in the relevant fields to make the job easier.

#### How should this be manually tested?

- Enter the system and go to create a workout
- Add an exercise to the workout
- The form will look like this once you have entered the specific exercise you want
<img width="560" alt="screen shot 2018-08-16 at 13 24 55" src="https://user-images.githubusercontent.com/33119403/44203549-f5a10f80-a157-11e8-9a20-5142977b6caf.png">

- One can now enter the details for the details for the drop set and have them calculated as shown below

<img width="805" alt="screen shot 2018-08-16 at 13 21 46" src="https://user-images.githubusercontent.com/33119403/44203597-33059d00-a158-11e8-97a4-f8cc396fea8c.png">
- Save once done

#### What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/159356717