### PR TITLE
#159356719 Make Translation Easy Update

### DIFF
--- a/wger/exercises/templates/exercise/overview.html
+++ b/wger/exercises/templates/exercise/overview.html
@@ -8,8 +8,8 @@
 <!--
         Title
 -->
-{% block title %}
-    {% trans "Exercises" %}
+{% block title %}{% trans "Exercises" %}
+
     <div class="btn-group" style="float: right;">
         <button type="button" class="btn btn-success dropdown-toggle btn-sm" data-toggle="dropdown">
             {% trans 'Filter by language' %}
@@ -19,9 +19,9 @@
             <li>
                 <a href={% url 'exercise:exercise:overview' %}>None
             </li>
-            {% for code, language in languages %}
+            {% for language_code, language in languages %}
                 <li>
-                    <a href={% url 'exercise:exercise:overview' %}?lang={{ code }}>{{ language }}
+                    <a href={% url 'exercise:exercise:overview' %}?lang={{ language_code }}>{{ language }}
                 </li>
             {% endfor %}
         </ul>
@@ -36,7 +36,6 @@
         </button>
     </div>
 {% endblock %}
-
 
 
 <!--

--- a/wger/exercises/tests/test_exercise.py
+++ b/wger/exercises/tests/test_exercise.py
@@ -85,8 +85,8 @@ class ExerciseIndexTestCase(WorkoutManagerTestCase):
         self.assertEqual(category_1.name, "Another category")
 
         category_2 = response.context['exercises'][1].category
-        self.assertEqual(category_2.id, 2)
-        self.assertEqual(category_2.name, "Another category")
+        self.assertEqual(category_2.id, 3)
+        self.assertEqual(category_2.name, "Yet another category")
 
         # Correct exercises in the categories
         exercises_1 = category_1.exercise_set.all()
@@ -258,6 +258,17 @@ class ExercisesTestCase(WorkoutManagerTestCase):
         self.user_logout()
         self.add_exercise_user_fail()
         self.user_logout()
+
+    def filter_exercise_by_language(self, admin=False):
+        '''
+        Tests adding/editing an exercise with a user with enough rights to do this
+        '''
+
+        # Add an exercise
+        count_before = Exercise.objects.count()
+        description = 'a nice, long and accurate description for the exercise'
+        response = self.client.post(reverse('exercise:exercise:overview'), params={lang: "en"})
+        self.assertEqual(response.status_code, 200)
 
     def add_exercise_success(self, admin=False):
         '''


### PR DESCRIPTION
### What does this PR do?
Makes it easy for a user to filter exercises and nutrition by original written language

### Description of Task to be completed?
There is already support for that, but it is probably a bit hidden:

Every ingredient and exercise has a field indicating the language, which is automatically set as the user's current language when adding them.
The current list is then filtered based on this.

The user should be able to select which languages to show. They should not be shown only their current language.

### Screenshots
<img width="781" alt="screen shot 2018-08-16 at 1 19 57 pm" src="https://user-images.githubusercontent.com/25157392/44263999-a88d6e00-a229-11e8-9839-698b309364ed.png">
